### PR TITLE
Add throttling configuration to REST framework settings

### DIFF
--- a/image_processing_service/settings.py
+++ b/image_processing_service/settings.py
@@ -67,6 +67,11 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {"anon": "10/day", "user": "100/day"},
 }
 
 ROOT_URLCONF = "image_processing_service.urls"


### PR DESCRIPTION
Added basic throttling with no custom definition by view.

` "DEFAULT_THROTTLE_RATES": {"anon": "10/day", "user": "100/day"}`